### PR TITLE
입문/구슬을 나누는 경우의 수

### DIFF
--- a/programmersJS/구슬을 나누는 경우의 수.js
+++ b/programmersJS/구슬을 나누는 경우의 수.js
@@ -1,0 +1,11 @@
+function solution(balls, share) {
+    let num = 1;
+    let dev = 1;
+    for (i = balls; i > share; i--) {
+        num *= i;
+    }
+    for (i = 1; i <= balls - share; i++) {
+        dev *= i;
+    }
+    return parseInt(num / dev);
+}


### PR DESCRIPTION
https://school.programmers.co.kr/learn/courses/30/lessons/120840

parseInt 없이 제출했을 때, 35번 케이스에서 실패했었음. 로직상으론 문제가 없어보여서 질문란을 확인해보니 '컴퓨터에서 소수를 0과 1로 표현할때 무한소수처럼 계속 이어지는 경우 어느 자리에서 끊어서 표현하는데 이 때 작은 오차가 발생하여 계산의 결과가 정수가 아닌 실수가 됩니다' 라는 답변이 있었음. 리턴값을 정수화시키니 통과함.